### PR TITLE
Return errors instead of panicking

### DIFF
--- a/dict.go
+++ b/dict.go
@@ -52,6 +52,11 @@ func DictionaryFromFileOrDie(path string) *Dictionary {
 	return d
 }
 
+func DictionaryFromFile(path string) (d *Dictionary, err error) {
+	err = d.LoadFromFile(path)
+	return
+}
+
 // DictionaryFromArrayOrDie loads a wordlist from the provided array and panics on errors
 func DictionaryFromArrayOrDie(words []string) *Dictionary {
 	d := &Dictionary{}

--- a/dict.go
+++ b/dict.go
@@ -53,6 +53,7 @@ func DictionaryFromFileOrDie(path string) *Dictionary {
 }
 
 func DictionaryFromFile(path string) (d *Dictionary, err error) {
+	d = &Dictionary{}
 	err = d.LoadFromFile(path)
 	return
 }

--- a/mnemonic.go
+++ b/mnemonic.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
+	"errors"
 	"fmt"
 	"log"
 
@@ -29,6 +30,27 @@ type Mnemonic struct {
 	dict       *Dictionary
 	wordLength int
 	lastWords  []string
+}
+
+func NewFromFile(path string) (m *Mnemonic, err error) {
+	dict, err := DictionaryFromFile(path)
+	if err != nil {
+		return
+	}
+
+	size := dict.Size()
+	if size == 0 || size&(size-1) != 0 {
+		err = errors.New(fmt.Sprintf("Unsupported dictionary size %d; must be power of two.", size))
+		return
+	}
+	var bits int
+	for ; size > 1; size >>= 1 {
+		bits++
+	}
+	return &Mnemonic{
+		dict:       dict,
+		wordLength: bits,
+	}, nil
 }
 
 // NewFromFileOrDie generates a mnemonic object based on the words from the


### PR DESCRIPTION
If this package is to be used imported by others, we want to give error handling control to users and avoid panicking.